### PR TITLE
Fix prefixed requests matching non-prefixed URLs

### DIFF
--- a/app/Listeners/CacheShortUrl.php
+++ b/app/Listeners/CacheShortUrl.php
@@ -38,12 +38,13 @@ class CacheShortUrl implements ShouldQueue
         $modelAttributes = $url->attributesToArray();
         if (!array_key_exists('domain_id', $modelAttributes)
             || !array_key_exists('organization_id', $modelAttributes)
-            || !array_key_exists('url', $modelAttributes)) {
+            || !array_key_exists('url', $modelAttributes)
+            || !array_key_exists('prefix', $modelAttributes)) {
             return;
         }
 
         $domain = $url->domain->url;
-        $prefix = $url->organization ? $url->organization->prefix : null;
+        $prefix = $url->prefix ? $url->organization->prefix : null;
         $urlName = $url->url;
 
         Cache::set(sprintf(Url::URL_CACHE_KEY, $domain, $prefix, $urlName), $url);

--- a/app/Services/UrlService.php
+++ b/app/Services/UrlService.php
@@ -20,9 +20,10 @@ class UrlService
             });
 
         if ($prefix) {
-            $urlQuery->whereHas('organization', function ($query) use ($prefix) {
-                $query->where('prefix', $prefix);
-            });
+            $urlQuery->where('prefix', true)
+                ->whereHas('organization', function ($query) use ($prefix) {
+                    $query->where('prefix', $prefix);
+                });
         }
 
         $urlModel = null;

--- a/tests/Unit/Listeners/CacheShortUrlTest.php
+++ b/tests/Unit/Listeners/CacheShortUrlTest.php
@@ -13,15 +13,30 @@ class CacheShortUrlTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    function caches_a_url()
+    function caches_prefixed_urls_with_a_prefix()
     {
         $url = null;
         Event::fakeFor(function () use (&$url) {
-            $url = factory(Url::class)->states('org')->create();
+            $url = factory(Url::class)->states('org')->create(['prefix' => true]);
         });
 
         event(new UrlSaved($url));
 
         $this->assertTrue(cache()->has(sprintf(Url::URL_CACHE_KEY, $url->domain->url, $url->organization->prefix, $url->url)));
+        $this->assertFalse(cache()->has(sprintf(Url::URL_CACHE_KEY, $url->domain->url, null, $url->url)));
+    }
+
+    /** @test */
+    function caches_non_prefixed_urls_without_a_prefix()
+    {
+        $url = null;
+        Event::fakeFor(function () use (&$url) {
+            $url = factory(Url::class)->states('org')->create(['prefix' => false]);
+        });
+
+        event(new UrlSaved($url));
+
+        $this->assertTrue(cache()->has(sprintf(Url::URL_CACHE_KEY, $url->domain->url, null, $url->url)));
+        $this->assertFalse(cache()->has(sprintf(Url::URL_CACHE_KEY, $url->domain->url, $url->organization->prefix, $url->url)));
     }
 }

--- a/tests/Unit/Services/UrlServiceTest.php
+++ b/tests/Unit/Services/UrlServiceTest.php
@@ -5,11 +5,10 @@ namespace Tests\Unit\Services;
 use App\Exceptions\CacheFallbackException;
 use App\Models\Url;
 use App\Services\UrlService;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\DB;
 use PDOException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Tests\TestCase;
 
 /**
@@ -66,5 +65,15 @@ class UrlServiceTest extends TestCase
         }
 
         $this->fail('Method getRedirectForUrl() did not throw an exception.');
+    }
+
+    /** @test */
+    function prefixed_requests_dont_match_non_prefixed_organization_urls()
+    {
+        $url = factory(Url::class)->states('org')->create(['prefix' => false]);
+        $service = new UrlService();
+
+        $this->expectException(NotFoundHttpException::class);
+        $service->getRedirectForUrl($url->domain->url, $url->url, $url->organization->prefix);
     }
 }


### PR DESCRIPTION
In the case where a request with a prefix is made to a URL associated
with an organization that has a prefix, and the URL is not a prefixed
URL, the request would match that URL anyway. This will no longer occur.