### PR TITLE
Add support for database-based bans

### DIFF
--- a/app/Entities/User.php
+++ b/app/Entities/User.php
@@ -89,6 +89,11 @@ class User extends Entity implements Authenticatable
     protected bool $admin = false;
 
     /**
+     * @ORM\Column(type="boolean", options={"default": 0})
+     */
+    protected bool $banned = false;
+
+    /**
      * @ORM\Column(type="string", nullable=true)
      */
     protected ?string $totpSecret = null;
@@ -254,6 +259,11 @@ class User extends Entity implements Authenticatable
         return $this->admin;
     }
 
+    public function isBanned()
+    {
+        return $this->banned;
+    }
+
     public function getVatsimConnectAccessToken(): ?string
     {
         return $this->vatsimConnectAccessToken;
@@ -317,6 +327,11 @@ class User extends Entity implements Authenticatable
     public function setAdmin(bool $admin): void
     {
         $this->admin = $admin;
+    }
+
+    public function setBanned(bool $banned): void
+    {
+        $this->banned = $banned;
     }
 
     public function routeNotificationForMail(Notification $notification)

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -58,6 +58,7 @@ class Kernel extends HttpKernel
         'platform' => [
             'auth:web',
             'two-factor',
+            'validate-ban-status',
             'validate-email',
         ],
     ];
@@ -83,6 +84,7 @@ class Kernel extends HttpKernel
         'admin' => \App\Http\Middleware\IsAdmin::class,
         'log-requests' => \App\Http\Middleware\LogRequests::class,
         'two-factor' => \App\Http\Middleware\TwoFactorAuth::class,
+        'validate-ban-status' => \App\Http\Middleware\CheckBanStatus::class,
         'validate-email' => \App\Http\Middleware\CheckEmailVerified::class,
     ];
 

--- a/app/Http/Middleware/CheckBanStatus.php
+++ b/app/Http/Middleware/CheckBanStatus.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class CheckBanStatus
+{
+    /**
+     * The URIs that should be excluded from ban validation.
+     *
+     * @var array
+     */
+    protected $except = [
+        'platform/register',
+        'platform/login',
+    ];
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if ($this->inExceptArray($request)) {
+            return $next($request);
+        }
+
+        $user = $request->user();
+        if ($user && ($user->isBanned() || in_array($user->getId(), config('auth.banned_users')))) {
+            Log::info('Request cancelled: banned user.', ['user' => $user]);
+
+            auth()->guard()->logout();
+            $request->session()->invalidate();
+
+            return redirect()->route('platform.login')
+                ->with('error', 'Request failed. You are not authorized to use this service.');
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Determine if the request has a URI that should pass through CSRF verification.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return bool
+     */
+    protected function inExceptArray($request)
+    {
+        foreach ($this->except as $except) {
+            if ($except !== '/') {
+                $except = trim($except, '/');
+            }
+
+            if ($request->fullUrlIs($except) || $request->is($except)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/database/migrations/2022_07_22_032056_add_banned_to_users_table.php
+++ b/database/migrations/2022_07_22_032056_add_banned_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddBannedToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('banned')->default(0)->after('admin');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('banned');
+        });
+    }
+}

--- a/tests/Unit/Middleware/CheckBanStatusTest.php
+++ b/tests/Unit/Middleware/CheckBanStatusTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\Middleware;
+
+use App\Entities\User;
+use App\Http\Middleware\CheckBanStatus;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Tests\TestCase;
+
+class CheckBanStatusTest extends TestCase
+{
+    /** @test */
+    public function ignores_unbanned_users()
+    {
+        $user = make(User::class);
+        $request = new Request();
+        $request->setUserResolver(function () use ($user) {
+            return $user;
+        });
+        $middleware = new CheckBanStatus();
+        $result = $middleware->handle($request, fn() => 'next');
+
+        $this->assertEquals('next', $result);
+    }
+
+    /** @test */
+    public function redirects_banned_users()
+    {
+        $user = make(User::class);
+        $user->setBanned(true);
+        $request = new Request();
+        $request->setUserResolver(function () use ($user) {
+            return $user;
+        });
+        $request->setSession(new Session());
+        $middleware = new CheckBanStatus();
+        $result = $middleware->handle($request, fn() => 'next');
+
+        $this->assertNotEquals('next', $result);
+        $this->assertArrayHasKey('error', $result->getSession()->all());
+    }
+}


### PR DESCRIPTION
Previously, bans have been configured via the application
configuration/environment. We now _also_ support marking users as banned
in the database, and we now enforce both ban methods with middleware.