### PR TITLE
Avoid unnecessary selection of organisation users

### DIFF
--- a/app/Repositories/OrganizationRepository.php
+++ b/app/Repositories/OrganizationRepository.php
@@ -14,7 +14,7 @@ class OrganizationRepository extends Repository
         int $page = null
     ) {
         $query = $this->createQueryBuilder('o')
-            ->select('o, ou')
+            ->select('o')
             ->join('o.organizationUsers', 'ou', 'WITH', "ou.user = {$user->getId()}")
             ->orderBy("o.$orderBy", $order)
             ->getQuery();


### PR DESCRIPTION
This was selecting the single user in question and hydrating the organisations' `OrganizationUser` collection with just a single user. Avoiding this select will properly hydrate each organisation.